### PR TITLE
Handle no user images

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,7 +65,7 @@ class User < ActiveRecord::Base
     user.uid = auth.info.id
     user.name = auth.info.display_name
     user.email = auth.info.email
-    user.image_url = auth.info.images.first.url
+    user.image_url = auth.info.images.first.try(:url)
     user.profile_url = auth.info.external_urls[:spotify]
     user.oauth_token = auth["credentials"]["token"]
     user.oauth_expires_at = auth["credentials"]["expires_at"]


### PR DESCRIPTION
* Handle scenario where a user does not have any Spotify images. Currently, the oauth flow blows up with an undefined method `url` on nilClass error